### PR TITLE
Fix sleep pose for the Locobot

### DIFF
--- a/interbotix_ros_xsarms/interbotix_xsarm_control/config/wx200.yaml
+++ b/interbotix_ros_xsarms/interbotix_xsarm_control/config/wx200.yaml
@@ -1,7 +1,7 @@
 port: /dev/ttyDXL
 
 joint_order: [waist, shoulder, elbow, wrist_angle, wrist_rotate, gripper]
-sleep_positions: [0, -1.88, 1.5, 0.8, 0, 0]
+sleep_positions: [0, -1.35, 1.5, 0.8, 0, 0]
 
 joint_state_publisher:
   update_rate: 100

--- a/interbotix_ros_xsarms/interbotix_xsarm_moveit/config/srdf/wx200.srdf.xacro
+++ b/interbotix_ros_xsarms/interbotix_xsarm_moveit/config/srdf/wx200.srdf.xacro
@@ -48,7 +48,7 @@
     </group_state>
     <group_state name="Sleep" group="interbotix_arm">
         <joint name="elbow" value="1.55" />
-        <joint name="shoulder" value="-1.88" />
+        <joint name="shoulder" value="-1.35" />
         <joint name="waist" value="0" />
         <joint name="wrist_angle" value="0.8" />
         <joint name="wrist_rotate" value="0" />


### PR DESCRIPTION
I adjusted the angle so that it should rest nicely above the arm support without forcing (1.36 or 1.37 be more touching the support).  I think the yaml addresses the bartender.py demo, while  srdf addresses the issues with the moveit demo code of EricC